### PR TITLE
docs(readme): add ClawHub download history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,3 +711,7 @@ If you encounter any errors or issues, please send the error message, logs, or s
 ## License
 
 MIT
+
+## Download History
+
+[![Download History](https://skill-history.com/chart/zw008/vmware-monitor.svg)](https://skill-history.com/zw008/vmware-monitor)


### PR DESCRIPTION
Hey! 👋

I'm Gavin — I built [skill-history.com](https://skill-history.com), a free tool that tracks ClawHub skill download history over time (think [star-history.com](https://star-history.com) but for agent skills).

I noticed your skill **Vmware Monitor** has been getting traction — **882 downloads** so far — so I set up a chart page for it:

👉 **https://skill-history.com/zw008/vmware-monitor**

This PR adds a small download history section to the bottom of your README with a live-updating chart that refreshes daily. Here's what it looks like:

![Preview](https://skill-history.com/chart/zw008/vmware-monitor.svg)

No setup, no tokens, no CI changes — just an SVG embed that auto-updates.

If you'd prefer a compact badge instead of the full chart, you can swap it for this:

![Downloads](https://skill-history.com/badge/zw008/vmware-monitor.svg)

`![Downloads](https://skill-history.com/badge/zw008/vmware-monitor.svg)`

The whole thing is open source: **[github.com/pineapple-farm/skill-history](https://github.com/pineapple-farm/skill-history)**

It's a brand new project and I'm shaping it based on what skill authors actually want. If you have any feedback, feature requests, or ideas:

- [Open an issue](https://github.com/pineapple-farm/skill-history/issues/new)
- Submit a PR
- Or just drop a comment here

Totally understand if this isn't your thing — feel free to close. But if it's useful, I'm excited to see it on your README!

Cheers,
Gavin
[Pineapple AI](https://pineappleai.com)