### PR TITLE
feat: add vCenter folder path to VM inventory

### DIFF
--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -86,26 +86,40 @@ def list_virtual_machines(
     sort_by: str = "name",
     power_state: str | None = None,
     fields: list[str] | None = None,
+    folder_filter: str | None = None,
 ) -> dict:
     """[READ] List virtual machines with optional filtering, sorting, and field selection.
 
-    Returns a dict: {total, mode, vms, hint}.
+    Returns a dict: {total, mode, vms, hint}. Each VM entry includes a
+    ``folder_path`` field showing the vCenter inventory folder path
+    (e.g. ``/Colocation/Colo - ISER``).
+
     Auto-compact: when no limit/fields are set and inventory exceeds 50 VMs,
-    returns compact fields (name, power_state, cpu, memory_mb) to keep context
-    manageable. Set limit or fields to override.
+    returns compact fields (name, power_state, cpu, memory_mb, folder_path) to
+    keep context manageable. Set limit or fields to override.
 
     Args:
         target: Optional vCenter/ESXi target name from config. Uses default if omitted.
         limit: Max number of VMs to return (None = all).
-        sort_by: Sort field: "name" | "cpu" | "memory_mb" | "power_state".
+        sort_by: Sort field: "name" | "cpu" | "memory_mb" | "power_state" | "folder_path".
         power_state: Filter by power state: "poweredOn" | "poweredOff" | "suspended".
         fields: Return only these fields (None = auto-select based on inventory size).
             Available: name, power_state, cpu, memory_mb, guest_os, ip_address,
-                       host, uuid, tools_status.
+                       host, uuid, tools_status, folder_path.
+        folder_filter: Case-insensitive substring match against folder_path.
+            Example: ``folder_filter="Colocation"`` returns VMs anywhere under
+            a Colocation folder, including nested subfolders.
     """
     try:
         si = _get_connection(target)
-        return list_vms(si, limit=limit, sort_by=sort_by, power_state=power_state, fields=fields)
+        return list_vms(
+            si,
+            limit=limit,
+            sort_by=sort_by,
+            power_state=power_state,
+            fields=fields,
+            folder_filter=folder_filter,
+        )
     except Exception as e:
         return {"error": str(e), "hint": "Run 'vmware-monitor doctor' to verify connectivity and credentials."}
 

--- a/tests/test_folder_path.py
+++ b/tests/test_folder_path.py
@@ -1,0 +1,68 @@
+"""Tests for the folder_path helper in vmware_monitor.ops.inventory."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from pyVmomi import vim
+
+from vmware_monitor.ops.inventory import folder_path
+
+
+def _mock_entity(name: str, parent=None, spec=vim.Folder):
+    """Build a MagicMock that ``isinstance`` will treat as ``spec``."""
+    m = MagicMock(spec=spec)
+    m.name = name
+    m.parent = parent
+    return m
+
+
+def test_folder_path_root_vmfolder_returns_slash():
+    """A VM sitting directly in the dc-level vmFolder yields '/'."""
+    dc = _mock_entity("UAA Datacenter", spec=vim.Datacenter)
+    vmfolder = _mock_entity("vm", parent=dc, spec=vim.Folder)
+    vm = _mock_entity("anc-orphan", parent=vmfolder, spec=vim.VirtualMachine)
+
+    assert folder_path(vm) == "/"
+
+
+def test_folder_path_one_level():
+    """One folder under the vmFolder."""
+    dc = _mock_entity("UAA Datacenter", spec=vim.Datacenter)
+    vmfolder = _mock_entity("vm", parent=dc, spec=vim.Folder)
+    colo = _mock_entity("Colocation", parent=vmfolder, spec=vim.Folder)
+    vm = _mock_entity("anc-iser-app01", parent=colo, spec=vim.VirtualMachine)
+
+    assert folder_path(vm) == "/Colocation"
+
+
+def test_folder_path_nested_subfolders():
+    """Two-level nesting under the vmFolder."""
+    dc = _mock_entity("UAA Datacenter", spec=vim.Datacenter)
+    vmfolder = _mock_entity("vm", parent=dc, spec=vim.Folder)
+    colo = _mock_entity("Colocation", parent=vmfolder, spec=vim.Folder)
+    iser = _mock_entity("Colo - ISER", parent=colo, spec=vim.Folder)
+    vm = _mock_entity("anc-iser-app01", parent=iser, spec=vim.VirtualMachine)
+
+    assert folder_path(vm) == "/Colocation/Colo - ISER"
+
+
+def test_folder_path_ignores_datacenter_name():
+    """Datacenter name is never part of the path."""
+    dc = _mock_entity("Some Other DC", spec=vim.Datacenter)
+    vmfolder = _mock_entity("vm", parent=dc, spec=vim.Folder)
+    colo = _mock_entity("Colocation", parent=vmfolder, spec=vim.Folder)
+    vm = _mock_entity("anc-iser-app01", parent=colo, spec=vim.VirtualMachine)
+
+    result = folder_path(vm)
+    assert "Some Other DC" not in result
+    assert result == "/Colocation"
+
+
+def test_folder_path_no_parent_chain():
+    """A VM with no parent at all returns '/'."""
+    vm = SimpleNamespace(parent=None)
+
+    assert folder_path(vm) == "/"

--- a/vmware_monitor/ops/inventory.py
+++ b/vmware_monitor/ops/inventory.py
@@ -23,8 +23,51 @@ def _get_objects(si: ServiceInstance, obj_type: list, recursive: bool = True) ->
         container.Destroy()
 
 
-_VM_SORT_KEYS = {"name", "cpu", "memory_mb", "power_state"}
-_COMPACT_FIELDS = ("name", "power_state", "cpu", "memory_mb")
+def folder_path(managed_entity) -> str:
+    """Return the vCenter inventory folder path for a managed entity.
+
+    Walks ``parent`` references up the inventory tree, stopping at the
+    enclosing Datacenter. The Datacenter's root vmFolder (named ``vm`` by
+    default) is omitted so the returned path matches what users see in the
+    vSphere UI under "VMs and Templates".
+
+    Args:
+        managed_entity: Any vim.ManagedEntity (VirtualMachine, Folder, etc.).
+
+    Returns:
+        Forward-slash separated path beginning with ``/``. Returns ``"/"`` for
+        entities that sit directly in the datacenter vmFolder. vApps are
+        included in the path as folders.
+
+    Examples:
+        ``"/"`` — VM at the root of the datacenter vmFolder
+        ``"/Colocation"`` — VM in a top-level "Colocation" folder
+        ``"/Colocation/Colo - ISER"`` — VM nested in a department subfolder
+        ``"/My vApp"`` — VM inside a vApp at the root
+    """
+    parts: list[str] = []
+    p = getattr(managed_entity, "parent", None)
+    # Walk upward, stopping at the Datacenter boundary so the path is
+    # relative to the dc-level vmFolder (which is itself omitted).
+    while p is not None:
+        if isinstance(p, vim.Datacenter):
+            break
+        # Skip the dc's root vmFolder ("vm"); its direct parent is the dc.
+        if isinstance(p, vim.Folder) and isinstance(getattr(p, "parent", None), vim.Datacenter):
+            break
+        parts.append(sanitize(p.name))
+        p = getattr(p, "parent", None)
+    if not parts:
+        return "/"
+    return "/" + "/".join(reversed(parts))
+
+
+_VM_SORT_KEYS = {"name", "cpu", "memory_mb", "power_state", "folder_path"}
+_COMPACT_FIELDS = ("name", "power_state", "cpu", "memory_mb", "folder_path")
+_VM_VALID_FIELDS = {
+    "name", "power_state", "cpu", "memory_mb", "guest_os",
+    "ip_address", "host", "uuid", "tools_status", "folder_path",
+}
 
 
 def list_vms(
@@ -33,6 +76,7 @@ def list_vms(
     sort_by: str = "name",
     power_state: str | None = None,
     fields: list[str] | None = None,
+    folder_filter: str | None = None,
     compact_threshold: int = 50,
 ) -> dict:
     """List virtual machines with optional filtering, sorting, and field selection.
@@ -50,11 +94,14 @@ def list_vms(
     Args:
         si: vSphere ServiceInstance.
         limit: Max number of VMs to return (None = all).
-        sort_by: Sort field: "name" | "cpu" | "memory_mb" | "power_state".
+        sort_by: Sort field: "name" | "cpu" | "memory_mb" | "power_state" | "folder_path".
         power_state: Filter by power state: "poweredOn" | "poweredOff" | "suspended".
         fields: Return only these fields (None = auto).
             Available: name, power_state, cpu, memory_mb, guest_os, ip_address,
-                       host, uuid, tools_status.
+                       host, uuid, tools_status, folder_path.
+        folder_filter: Case-insensitive substring match against folder_path.
+            Example: "Colocation" returns VMs anywhere under a Colocation folder
+            (including nested subfolders like /Colocation/Colo - ISER).
         compact_threshold: Auto-compact when VM count exceeds this (default 50).
     """
     vms = _get_objects(si, [vim.VirtualMachine])
@@ -71,12 +118,18 @@ def list_vms(
             "host": sanitize(vm.runtime.host.name) if vm.runtime.host else "N/A",
             "uuid": config.uuid if config else "N/A",
             "tools_status": str(vm.guest.toolsRunningStatus) if vm.guest else "N/A",
+            "folder_path": folder_path(vm),
         }
         results.append(entry)
 
     # Filter by power state
     if power_state:
         results = [r for r in results if power_state.lower() in r["power_state"].lower()]
+
+    # Filter by folder path (case-insensitive substring)
+    if folder_filter:
+        needle = folder_filter.lower()
+        results = [r for r in results if needle in r["folder_path"].lower()]
 
     # Sort
     sort_key = sort_by if sort_by in _VM_SORT_KEYS else "name"
@@ -104,9 +157,7 @@ def list_vms(
         mode = "full"
         hint = None
         if fields:
-            valid = {"name", "power_state", "cpu", "memory_mb", "guest_os",
-                     "ip_address", "host", "uuid", "tools_status"}
-            keep = [f for f in fields if f in valid]
+            keep = [f for f in fields if f in _VM_VALID_FIELDS]
             if keep:
                 results = [{k: r[k] for k in keep if k in r} for r in results]
 

--- a/vmware_monitor/ops/vm_info.py
+++ b/vmware_monitor/ops/vm_info.py
@@ -13,7 +13,7 @@ from pyVmomi import vim
 
 from vmware_policy import sanitize
 
-from vmware_monitor.ops.inventory import find_vm_by_name
+from vmware_monitor.ops.inventory import find_vm_by_name, folder_path
 
 if TYPE_CHECKING:
     from pyVmomi.vim import ServiceInstance
@@ -68,6 +68,7 @@ def get_vm_info(si: ServiceInstance, vm_name: str) -> dict:
         "uuid": config.uuid if config else "N/A",
         "instance_uuid": config.instanceUuid if config else "N/A",
         "host": sanitize(runtime.host.name) if runtime.host else "N/A",
+        "folder_path": folder_path(vm),
         "ip_address": guest.ipAddress if guest else None,
         "hostname": sanitize(guest.hostName) if guest and guest.hostName else None,
         "tools_status": str(guest.toolsRunningStatus) if guest else "N/A",


### PR DESCRIPTION
Surfaces the vCenter inventory folder path as a `folder_path` field on every VM
returned by `list_virtual_machines` and `get_vm_info`, plus an opt-in
`folder_filter` arg on `list_virtual_machines` for substring matching.

## What's added

* `folder_path()` helper in `ops/inventory.py` - walks `parent` chain up to the
  enclosing Datacenter, omitting the dc-level vmFolder so the returned path
  matches what's shown in the vSphere UI under "VMs and Templates".
  * `"/"` for VMs sitting directly in the dc vmFolder
  * `"/Colocation"` for top-level folders
  * `"/Colocation/Colo - ISER"` for nested
  * vApps appear as folders in the path
* `list_vms` (and the `list_virtual_machines` MCP tool) gain a `folder_filter`
  arg - case-insensitive substring match against `folder_path`. Defaults to
  `None` (no filtering).
* `folder_path` added to the auto-compact field set so folder context survives
  large-inventory mode (>50 VMs).
* `folder_path` accepted as a sort key.

## What's NOT changed

Read-only and additive. No existing field shapes change, no existing args are
modified, no new dependencies are introduced. Existing callers keep working
unchanged. The new arg defaults to off.

## Tests

5 unit tests in `tests/test_folder_path.py`, all mocked (no live vCenter
required):

* root vmFolder -> `/`
* one-level folder -> `/Foo`
* nested folders -> `/Foo/Bar`
* datacenter name never appears in path
* missing parent chain -> `/`

vApp pathing isn't covered by a unit test yet - happy to add one if you'd
like, just wanted to flag it.

## Real-world validation

Running on a production vCenter (~200 VMs across nested folder hierarchies
including vApps and the dc-level vmFolder) for the past few days with no
issues observed.

## Open to iteration

First time contributing to this project - happy to adjust naming, tighten scope, or split into smaller commits if any of that would help review. Thanks for maintaining this!
